### PR TITLE
Fix version conflicts caused by PR#83

### DIFF
--- a/src/shared/Microsoft.Git.CredentialManager/Microsoft.Git.CredentialManager.csproj
+++ b/src/shared/Microsoft.Git.CredentialManager/Microsoft.Git.CredentialManager.csproj
@@ -18,8 +18,8 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="5.5.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.18.5" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.35.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.18.8" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.Identity.Client.Extensions.Msal from 2.18.5 to 2.18.8. [(PR#83)](https://github.com/sawyeriii/Git-Credential-Manager-Core/pull/83).
Hope this fix can help you.

Best regards,
sucrose